### PR TITLE
Fix issue with plugin IDs not starting with `com`

### DIFF
--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -92,7 +92,7 @@ export default class Watch extends Command {
     await checkPath(elgatoPluginsPath, "Elgato plugins path not found");
 
     const [pluginFullName, pluginUID] = sourcePluginPath.match(
-      /((?:[\w-]+\.){1,3}?[\w-]+)\.sdPlugin/i
+      /([\w\.-]+)\.sdPlugin/i
     );
 
     const destinationPath = path.resolve(elgatoPluginsPath, pluginFullName);

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -92,7 +92,7 @@ export default class Watch extends Command {
     await checkPath(elgatoPluginsPath, "Elgato plugins path not found");
 
     const [pluginFullName, pluginUID] = sourcePluginPath.match(
-      /(com[a-z\.]*).sdPlugin/i
+      /((?:[\w-]+\.){1,3}?[\w-]+)\.sdPlugin/i
     );
 
     const destinationPath = path.resolve(elgatoPluginsPath, pluginFullName);


### PR DESCRIPTION
I was trying to use this tool with a plugin I began writing tonight, but I kept getting a TypeError at runtime. Looking through the code, I found this particular regex wasn't matching my plugin ID, even though it passed validation from the distribution tool and could be installed and run without a problem.

The change to that regex that I made allows for any plugin in the reverse domain name format to be validated, including plugins using TLDs with two parts to it like `co.uk` and the like. Additionally, this should now also allow the use of numbers in package names, which the original regex omitted. This should more closely match the validation behavior of the distribution tool.